### PR TITLE
fix(command): replace backslash with slash

### DIFF
--- a/honeybee_radiance_command/_command.py
+++ b/honeybee_radiance_command/_command.py
@@ -171,7 +171,7 @@ class Command(object):
         Returns:
             - int: Command return code.
         """
-        cmd = self.to_radiance()
+        cmd = self.to_radiance().replace('\\', '/')
         rc = run_command(cmd, env, cwd)
         self.after_run()
         return rc


### PR DESCRIPTION
Make sure all \ are replaced by / before processing the command. This might become an issue if one uses \ to escape a character but I won't be worried about that at this point. 