### PR TITLE
feat(image): Add several commands for image processing

### DIFF
--- a/honeybee_radiance_command/evalglare.py
+++ b/honeybee_radiance_command/evalglare.py
@@ -1,16 +1,29 @@
-"""falsecolor command."""
+"""evalglare command."""
 
-from .options.falsecolor import FalsecolorOptions
+from .options.evalglare import EvalglareOptions
 from ._command import Command
 import honeybee_radiance_command._exception as exceptions
 import honeybee_radiance_command._typing as typing
 
 
-class Falsecolor(Command):
-    """Falsecolor command.
+class Evalglare(Command):
+    """Evalglare command.
 
-    Falsecolor produces a false color picture for lighting analysis. Input is a
-    rendered Radiance picture.
+    Evalglare determines and evaluates glare sources within a 180 degree fisheye image,
+    given in the RADIANCE image format (.pic or .hdr).
+
+    The image should be rendered as fisheye (e.g. using the -vta or -vth option)
+    using 180 degrees for the horizontal and vertical view angle (-vv 180, -vh 180.)
+    Due to runtime reasons of the evalglare code, the image should be smaller
+    than 1500x1500 pixels. The recommended size is 1000x1000 pixels, the minimum
+    recommended size is 800x800 pixels.
+
+    The program calculates the daylight glare probability (DGP) as well as other
+    glare indexes (DGI, DGI_MOD, UGR, UGR_EXP, VCP, CGI, UDP) to the standard
+    output. The DGP describes the fraction of persons disturbed caused by glare
+    from daylight as a number from 0 to 1, where 0 is no-one disturbed and 1 is
+    everyone. Values lower than 0.2 are out of the range of the user assessment
+    tests, where the program is based on and should be interpreted carefully.
 
     Args:
         options: Command options. It will be set to Radiance default values
@@ -34,16 +47,16 @@ class Falsecolor(Command):
 
     @property
     def options(self):
-        """falsecolor options."""
+        """evalglare options."""
         return self._options
 
     @options.setter
     def options(self, value):
         if not value:
-            value = FalsecolorOptions()
+            value = EvalglareOptions()
 
-        if not isinstance(value, FalsecolorOptions):
-            raise ValueError('Expected Falsecolor options not {}'.format(value))
+        if not isinstance(value, EvalglareOptions):
+            raise ValueError('Expected Evalglare options not {}'.format(value))
 
         self._options = value
 
@@ -74,7 +87,7 @@ class Falsecolor(Command):
         cmd = ' '.join(command_parts)
 
         if not stdin_input and self.input:
-            cmd = '%s -i %s' % (cmd, self.input)
+            cmd = '%s %s' % (cmd, self.input)
 
         if self.pipe_to:
             cmd = '%s | %s' % (cmd, self.pipe_to.to_radiance(stdin_input=True))

--- a/honeybee_radiance_command/gendaylit.py
+++ b/honeybee_radiance_command/gendaylit.py
@@ -11,6 +11,14 @@ from .gensky import Gensky
 class Gendaylit(Gensky):
     """Gendaylit Command.
 
+    Gendaylit produces a RADIANCE scene description based on an angular distribution
+    of the daylight sources (direct+diffuse) for the given atmospheric conditions
+    (direct and diffuse component of the solar radiation), date and local standard
+    time. The default output is the radiance of the sun (direct) and the sky (diffuse)
+    integrated over the visible spectral range (380-780 nm). We have used the
+    calculation of the sun's position and the ground brightness models which
+    were programmed in gensky.
+
     Args:
         month: An integer representing the number of the month. Count starts from 01.
         day: An integer representing the number of the day in a month. Count starts
@@ -27,18 +35,18 @@ class Gendaylit(Gensky):
         solar_time: A boolean to use local solar time. If set to True then the time
             is preceded by '+' sign and local solar time is used instead of local
             standard time.
-        options: Command options. It will be set to Radiance default values if not
-            provided by user.
+        options: Command options. It will be set to Radiance default values
+            if unspecified.
         output: File path to the output file (Default: None).
     
     Properties:
-        *options
-        *month
-        *day
-        *time
-        *time_zone
-        *solar_time
-        *input
+        * options
+        * month
+        * day
+        * time
+        * time_zone
+        * solar_time
+        * input
     """
 
     __slots__ = ('_month', '_day', '_time', '_time_zone', '_solar_time', '_input')

--- a/honeybee_radiance_command/gendaymtx.py
+++ b/honeybee_radiance_command/gendaymtx.py
@@ -16,18 +16,23 @@ class Gendaymtx(Command):
     to compute a column in the output matrix, where rows correspond to sky patch
     positions, starting with 0 for the ground and continuing to 145 for the zenith using
     the default -m 1 parameter setting.
+
+    Args:
+        options: Gendaymtx options. It will be set to Radiance default values
+            if unspecified.
+        output: Path to output file.
+        wea: Path to input wea file.
+
+    Properties:
+        * options
+        * output
+        * wea
     """
 
     __slots__ = ('_wea',)
 
     def __init__(self, options=None, output=None, wea=None):
-        """Gendaymtx.
-
-        Args:
-            options. Gendaymtx options.
-            output: Path to output file.
-            wea: Path to input wea file.
-        """
+        """Initialize Command."""
         Command.__init__(self, output=output)
         self.wea = wea
         self.options = options

--- a/honeybee_radiance_command/gensky.py
+++ b/honeybee_radiance_command/gensky.py
@@ -11,6 +11,11 @@ import honeybee_radiance_command._exception as exceptions
 class Gensky(Command):
     """Gensky Command.
 
+    Gensky produces a RADIANCE scene description for the CIE standard sky
+    distribution at the given month, day and time. By default, the time is
+    interpreted as local standard time on a 24-hour clock. The time value may
+    be given either as decimal hours, or using a colon to separate hours and minutes.
+
     Args:
         month: An integer representing the number of the month. Count starts from 01.
         day: An integer representing the number of the day in a month. Count starts
@@ -27,18 +32,18 @@ class Gensky(Command):
         solar_time: A boolean to use local solar time. If set to True then the time
             is preceded by '+' sign and local solar time is used instead of local
             standard time.
-        options: Command options. It will be set to Radiance default values if not
-            provided by user.
+        options: Command options. It will be set to Radiance default values
+            if unspecified.
         output: File path to the output file (Default: None).
 
     Properties
-        *options
-        *month
-        *day
-        *time
-        *time_zone
-        *solar_time
-        *input
+        * options
+        * month
+        * day
+        * time
+        * time_zone
+        * solar_time
+        * input
     """
 
     __slots__ = ('_month', '_day', '_time', '_time_zone', '_solar_time', '_input')

--- a/honeybee_radiance_command/getinfo.py
+++ b/honeybee_radiance_command/getinfo.py
@@ -1,22 +1,29 @@
-"""falsecolor command."""
+"""getinfo command."""
 
-from .options.falsecolor import FalsecolorOptions
+from .options.getinfo import GetinfoOptions
 from ._command import Command
+
 import honeybee_radiance_command._exception as exceptions
 import honeybee_radiance_command._typing as typing
 
 
-class Falsecolor(Command):
-    """Falsecolor command.
 
-    Falsecolor produces a false color picture for lighting analysis. Input is a
-    rendered Radiance picture.
+class Getinfo(Command):
+    """Getinfo command.
+
+    Getinfo reads the header of each RADIANCE file and writes it to the standard
+    output. Octree and picture files are in a binary format, which makes it
+    difficult to determine their content. Therefore, a few lines of text are
+    placed at the beginning of each file by the RADIANCE program that creates it.
+    The end of the header information and the start of the data is indicated
+    by an empty line.
 
     Args:
         options: Command options. It will be set to Radiance default values
             if unspecified.
         output: File path to the output file (Default: None).
-        input: File path to the radiance generated hdr file (Default: None).
+        input: A list of paths to radiance generated hdr images, octree files,
+            etc. (Default: None).
 
     Properties:
         * options
@@ -24,41 +31,41 @@ class Falsecolor(Command):
         * input
     """
 
-    __slots__ = ('_input',)
+    __slots__ = ('_input')
 
     def __init__(self, options=None, output=None, input=None):
         """Initialize Command."""
         Command.__init__(self, output=output)
-        self.options = options
         self._input = input
+        self.options = options
 
     @property
     def options(self):
-        """falsecolor options."""
+        """getinfo options."""
         return self._options
 
     @options.setter
     def options(self, value):
         if not value:
-            value = FalsecolorOptions()
+            value = GetinfoOptions()
 
-        if not isinstance(value, FalsecolorOptions):
-            raise ValueError('Expected Falsecolor options not {}'.format(value))
+        if not isinstance(value, GetinfoOptions):
+            raise ValueError('Expected GetinfoOptions not {}'.format(type(value)))
 
         self._options = value
 
     @property
     def input(self):
-        """Radiance HDR image file."""
+        """A string of joined paths to the hdr or octree files."""
         return self._input
 
     @input.setter
     def input(self, value):
-        if value[-4:].lower() not in ('.hdr', '.pic'):
-            raise ValueError('"{}" does not have the expected extension for a Radiance '
-                             'generated HDR.'.format(type(value)))
-        else:
-            self._input = typing.normpath(value)
+        if not value:
+            self._input = []
+        elif not isinstance(value, (list, tuple)):
+            value = [value]
+        self._input = ' '.join(typing.normpath(path) for path in value)
 
     def to_radiance(self, stdin_input=False):
         """Command in Radiance format.
@@ -66,7 +73,7 @@ class Falsecolor(Command):
         Args:
             stdin_input: A boolean that indicates if the input for this command
                 comes from stdin. This is for instance the case when you pipe the input
-                from another command. (Default: False).
+                from another command (default: False).
         """
         self.validate(stdin_input)
 
@@ -74,13 +81,13 @@ class Falsecolor(Command):
         cmd = ' '.join(command_parts)
 
         if not stdin_input and self.input:
-            cmd = '%s -i %s' % (cmd, self.input)
+            cmd = ' '.join((cmd, self.input))
 
         if self.pipe_to:
-            cmd = '%s | %s' % (cmd, self.pipe_to.to_radiance(stdin_input=True))
+            cmd = ' | '.join((cmd, self.pipe_to.to_radiance(stdin_input=True)))
 
         elif self.output:
-            cmd = '%s > %s' % (cmd, self.output)
+            cmd = ' > '.join((cmd, self.output))
 
         return ' '.join(cmd.split())
 

--- a/honeybee_radiance_command/oconv.py
+++ b/honeybee_radiance_command/oconv.py
@@ -6,18 +6,31 @@ import honeybee_radiance_command._typing as typing
 
 
 class Oconv(Command):
-    """oconv command."""
+    """Oconv command.
+
+    Oconv adds each scene description input to octree and sends the result to the
+    standard output. Each input can be either a file name, or a command (enclosed
+    in quotes and preceded by a '!'). Similarly, the octree input may be given as
+    a command preceded by a '!'. If any of the surfaces will not fit in octree,
+    an error message is printed and the program aborts. If no octree is given, a
+    new one is created large enough for all of the surfaces.
+
+    Args:
+        options: Oconv command options. It will be set to Radiance default values
+            if unspecified.
+        output: Output file (Default: None).
+        inputs: A collection of scene files (Default: None)
+
+    Properties:
+        * options
+        * output
+        * input
+    """
 
     __slots__ = ('_inputs',)
 
     def __init__(self, options=None, output=None, inputs=None):
-        """Oconv command.
-
-        Args:
-            options: Oconv command (Default: OconvOptions()).
-            output: Output file (Default: None).
-            inputs: A collection of scene files (Default: [])
-        """
+        """Initialize Command."""
         Command.__init__(self, output=output)
         self.inputs = inputs or []
         self.options = options

--- a/honeybee_radiance_command/options/evalglare.py
+++ b/honeybee_radiance_command/options/evalglare.py
@@ -1,0 +1,432 @@
+# coding: utf-8
+
+from .optionbase import (
+    OptionCollection,
+    BoolOption,
+    NumericOption,
+    StringOption,
+    IntegerOption,
+    TupleOption,
+    FileOption
+)
+
+
+class EvalglareOptions(OptionCollection):
+    """evalglare options.
+
+    Also see: https://www.radiance-online.org/learning/documentation/manual-pages/pdfs/evalglare.pdf/view
+    """
+
+    __slots__ = (
+        "_A",
+        "_B",
+        "_b",
+        "_c",
+        "_C",
+        "_d",
+        "_f",
+        "_g",
+        "_G",
+        "_i",
+        "_I",
+        "_l",
+        "_L",
+        "_N",
+        "_q",
+        "_r",
+        "_s",
+        "_t",
+        "_T",
+        "_u",
+        "_x",
+        "_y",
+        "_Y"
+    )
+
+    def __init__(self):
+        """evalglare command options."""
+
+        OptionCollection.__init__(self)
+        self._A = FileOption("A", "Masking file to study a certain area")
+        self._B = NumericOption("B", "Angle to calculate luminance of horizontal band")
+        self._b = NumericOption("b", "Threshold factor in cd/m2 - default: 2000")
+        self._c = FileOption("c", "Output check file path")
+        self._C = StringOption(
+            "C", "Correction mode - default l+",
+            valid_values=["0", "l+", "l-"], whole=True
+        )
+        self._d = BoolOption("d", "Enable detailed output - default: False")
+        self._f = BoolOption("f", "Forcing option for -vtv and black corners")
+        self._g = IntegerOption(
+            "g", "Cut field of view according to Guth; no eval", min_value=1, max_value=2
+        )
+        self._G = IntegerOption(
+            "G", "Cut field of view according to Guth; eval", min_value=1, max_value=2
+        )
+        self._i = NumericOption("i", "Externally measured vertical illuminance in lux")
+        self._I = TupleOption(
+            "I", "Externally measured illuminance as (Ev, y_max, y_min)",
+            value=None, length=3, numtype=float
+        )
+        self._l = TupleOption(
+            "l", "Circular one zone evaluation as (xpos, ypos, angle)",
+            value=None, length=3, numtype=float
+        )
+        self._L = TupleOption(
+            "L", "Circular two zone evaluation as (xpos, ypos, angle1, angle2)",
+            value=None, length=4, numtype=float
+        )
+        self._N = TupleOption(
+            "N", "Pixel replacement during overflow as (xpos, ypos, angle, Ev, fname)",
+            value=None, length=5, numtype=str
+        )
+        self._q = IntegerOption(
+            "q", "Background luminance calculation method - default: 0",
+            min_value=0, max_value=2
+        )
+        self._r = NumericOption(
+            "r", "Search radius (angle) between pixels - default: 0.2 radians"
+        )
+        self._s = BoolOption("s", "Enable smoothing function - default: False")
+        self._t = TupleOption(
+            "t", "Task position as (xpos, ypos, angle)",
+            value=None, length=3, numtype=float
+        )
+        self._T = TupleOption(
+            "T", "Task position (colored blue) as (xpos, ypos, angle)",
+            value=None, length=3, numtype=float
+        )
+        self._u = TupleOption(
+            "u", "RGB color to color glare sources uniformly",
+            value=None, length=3, numtype=float
+        )
+        self._x = BoolOption("x", "Disable peak extraction - default: False")
+        self._y = BoolOption("y", "Enable peak extraction - default: True")
+        self._Y = NumericOption("Y", "Enable peak extraction with value in cd/m2")
+        self._on_setattr_check = True
+
+    def _on_setattr(self):
+        """This method executes after setting each new attribute.
+        """
+        warn = ' This program can use either of the options but not both.'
+        if self._g.is_set and self._G.is_set:
+            raise ValueError('Both -g and -G do not go well together.' + warn)
+        if self._i.is_set and self._I.is_set:
+            raise ValueError('Both -i and -I do not go well together.' + warn)
+        if self._l.is_set and self._L.is_set:
+            raise ValueError('Both -l and -L do not go well together.' + warn)
+        if self._t.is_set and self._T.is_set:
+            raise ValueError('Both -t and -T do not go well together.' + warn)
+        if self._y.is_set and self._Y.is_set:
+            raise ValueError('Both -y and -Y do not go well together.' + warn)
+        if self._A.is_set and (self._l.is_set or self._L.is_set):
+            raise ValueError('Both -A and -l/-L do not go well together.')
+
+    @property
+    def A(self):
+        """Masking file to study a certain area
+
+        Use a masking file to enable statistical analysis on a certain area.
+        Does not affect glare source detection. The masking threshold is 0.1 cd/m2
+        (all pixels exceeding 0.1 cd/m2 are treated as "inside" the mask.) The PGSV
+        equations are also calculated, but require the masking area to be the window.
+        It requires the -d option. The result of the analysis of the masking area
+        is given in the first line of the output. Should not be combined with
+        -l or -L options.
+        """
+        return self._A
+
+    @A.setter
+    def A(self, value):
+        self.A.value = value
+
+    @property
+    def B(self):
+        """Angle to calculate luminance of horizontal band
+
+        Calculate average luminance of a horizontal band. The angle is in radians.
+        This calculation does not affect glare source detection. Output only when
+        using the -d option. The result of the analysis of the band is given in
+        the first line of the output.
+        """
+        return self._B
+
+    @B.setter
+    def B(self, value):
+        self.B.value = value
+
+    @property
+    def b(self):
+        """Threshold factor in cd/m2 - default: 2000
+
+        Threshold factor; if factor is larger than 100, it is used as constant
+        threshold in cd/m2, regardless if a task position is given or not. If
+        factor is less or equal than 100 and a task position is given, this factor
+        multiplied by the average task luminance will be used as threshold for
+        detecting the glare sources. If factor is less than or equal to 100 and
+        no task position is given, this factor multiplied by the average luminance in
+        the entire picture will be used as threshold for detecting the glare
+        sources (not recommended). Default value of factor is 2000 (fixed
+        threshold method).
+        """
+        return self._b
+
+    @b.setter
+    def b(self, value):
+        self.b.value = value
+
+    @property
+    def c(self):
+        """Output check file path
+
+        Checkfile is written in the RADIANCE picture format.
+        """
+        return self._c
+
+    @c.setter
+    def c(self, value):
+        self.c.value = value
+
+    @property
+    def C(self):
+        """Correction mode - default l+
+
+        Type 0: all corrections turned off , Type l+: Low light correction applied
+        (default), Type l-: Low light correction disabled.
+        """
+        return self._C
+
+    @C.setter
+    def C(self, value):
+        self.C.value = value
+
+    @property
+    def d(self):
+        """Enable detailed output - default: False"""
+        return self._d
+
+    @d.setter
+    def d(self, value):
+        self.d.value = value
+
+    @property
+    def f(self):
+        """Forcing option for -vtv and black corners - default: False
+        
+        This forcing option prevents from stopping when -vtv is used and black
+        corners are detected.
+        """
+        return self._f
+
+    @f.setter
+    def f(self, value):
+        self.f.value = value
+
+    @property
+    def g(self):
+        """Cut field of view according to Guth with no glare evaluation
+        
+        Cut field of view according to Guth, write checkfile specified by -c and
+        exit without any glare evaluation. Type 1: total field of view. Type 2: field
+        of view seen by both eyes
+        """
+        return self._g
+
+    @g.setter
+    def g(self, value):
+        self.g.value = value
+
+    @property
+    def G(self):
+        """Cut field of view according to Guth and perform glare evaluation
+        
+        Type 1: total field of view. Type 2: field of view seen by both eyes
+        """
+        return self._G
+
+    @G.setter
+    def G(self, value):
+        self.G.value = value
+
+    @property
+    def i(self):
+        """Externally measured vertical illuminance in lux
+        
+        The vertical illuminance Ev in lux is measured externally. This value will
+        be used for calculating the DGP.
+        """
+        return self._i
+
+    @i.setter
+    def i(self, value):
+        self.i.value = value
+
+    @property
+    def I(self):
+        """Externally measured illuminance as (Ev, y_max, y_min)
+        
+        The vertical illuminance Ev in lux is measured externally. This value will
+        be used for calculating the DGP. Below y_min and above y_max, the picture
+        is filled up by the last known value. This option should be used, when
+        the provided picture is cut horizontally.
+        """
+        return self._I
+
+    @I.setter
+    def I(self, value):
+        self.I.value = value
+
+    @property
+    def l(self):
+        """Circular one zone evaluation as (xpos, ypos, angle)
+        
+        Activate circular one zone evaluation. The center of the zone is given by
+        xpos and ypos. The opening angle of the zone is specified in radians.
+        The result of the analysis of zone1 is given in the first line of the output.
+        """
+        return self._l
+
+    @l.setter
+    def l(self, value):
+        self.l.value = value
+
+    @property
+    def L(self):
+        """Circular two zone evaluation as (xpos, ypos, angle1, angle2)
+        
+        Activate circular two zone evaluation. The center of the zone is given by
+        xpos and ypos. The opening angle of the inner zone1 is specified by angle1
+        in radians, the opening angle of the outer zone2 by angle2. The result of
+        the analysis of the zones is given in the first two lines of the output.
+        """
+        return self._L
+
+    @L.setter
+    def L(self, value):
+        self.L.value = value
+
+    @property
+    def N(self):
+        """Pixel replacement during overflow as (xpos, ypos, angle, Ev, fname)
+        
+        Pixel replacement in case of pixel overflow in hdr image and measured Ev
+        (in lux) is available. Writes the modified image to fname and exists
+        immediately (without glare evaluation). Replaces pixels in a circular
+        zone to match Ev. The center of the zone is given by xpos and ypos. The
+        opening angle of the zone is specified in radians.
+        
+        This option should be applied very carefully and only exceptionally.
+        Pixel overflow should be avoided from the beginning by applying shorter
+        exposure times and/or neutral filters.
+        """
+        return self._N
+
+    @N.setter
+    def N(self, value):
+        self.N.value = value
+
+    @property
+    def q(self):
+        """Background luminance calculation method - default: 0
+
+        Toggle modes for the background luminance calculation.
+
+        * 0 (default) - CIE-mode Lb = (Ev - Edir) / pi
+        * 1 - Lb = mathematical average luminance without glare sources
+        * 2 (not recommended) - Lb = Ev / pi
+        """
+        return self._q
+
+    @q.setter
+    def q(self, value):
+        self.q.value = value
+
+    @property
+    def r(self):
+        """Search radius (angle) between pixels - default: 0.2 radians
+
+        Search radius (angle in radians) between pixels, where evalglare tries to merge
+        glare source pixels to the same glare source (default value: 0.2 radians)
+        """
+        return self._r
+
+    @r.setter
+    def r(self, value):
+        self.r.value = value
+
+    @property
+    def s(self):
+        """Enable smoothing function - default: False"""
+        return self._s
+
+    @s.setter
+    def s(self, value):
+        self.s.value = value
+
+    @property
+    def t(self):
+        """Task position as (xpos, ypos, angle)
+
+        Definition of task position in x and y coordinates, and its opening
+        angle in radians.
+        """
+        return self._t
+
+    @t.setter
+    def t(self, value):
+        self.t.value = value
+
+    @property
+    def T(self):
+        """Task position as (xpos, ypos, angle)
+
+        Same as -t, except that the task area is colored bluish in the checkfile.
+        """
+        return self._T
+
+    @T.setter
+    def T(self, value):
+        self.T.value = value
+
+    @property
+    def u(self):
+        """RGB color to color glare sources uniformly
+
+        Color glare sources uniformly when writing check file (implies -c option).
+        Color given in r g b. (in any range, values are normalized)
+        """
+        return self._u
+
+    @u.setter
+    def u(self, value):
+        self.u.value = value
+
+    @property
+    def x(self):
+        """Disable peak extraction - default: False"""
+        return self._x
+
+    @x.setter
+    def x(self, value):
+        self.x.value = value
+
+    @property
+    def y(self):
+        """Enable peak extraction - default: True"""
+        return self._y
+
+    @y.setter
+    def y(self, value):
+        self.y.value = value
+
+    @property
+    def Y(self):
+        """Enable peak extraction with value in cd/m2
+
+        Enable peak extraction with value (in cd/m2) as threshold for extracted peaks.
+        """
+        return self._Y
+
+    @Y.setter
+    def Y(self, value):
+        self.Y.value = value

--- a/honeybee_radiance_command/options/getinfo.py
+++ b/honeybee_radiance_command/options/getinfo.py
@@ -1,0 +1,34 @@
+# coding: utf-8
+
+from .optionbase import OptionCollection, BoolOption
+
+
+class GetinfoOptions(OptionCollection):
+    """getinfo options.
+
+    Also see: https://floyd.lbl.gov/radiance/man_html/getinfo.1.html
+    """
+
+    __slots__ = ('_d',)
+
+    def __init__(self):
+        """getinfo command options."""
+
+        OptionCollection.__init__(self)
+        self._d = BoolOption("d", "Print the dimensions instead - default: False")
+        self._on_setattr_check = False
+
+    @property
+    def d(self):
+        """Print the dimensions instead - default: False
+
+        The −d option can be used to print the dimensions of an octree or picture
+        file instead of getting the header. For an octree, getinfo −d prints the
+        bounding cube (xmin ymin zmin size). For a picture, getinfo −d prints the
+        y and x resolution (−Y yres +X xres).
+        """
+        return self._d
+
+    @d.setter
+    def d(self, value):
+        self._d.value = value

--- a/honeybee_radiance_command/options/optionbase.py
+++ b/honeybee_radiance_command/options/optionbase.py
@@ -25,8 +25,7 @@ class Option(object):
 
     @property
     def name(self):
-        return self._name if not self._name.endswith('_') \
-            else self._name.replace('_', '')
+        return self._name.replace('_', '')
 
     @name.setter
     def name(self, name):

--- a/honeybee_radiance_command/options/pcomb.py
+++ b/honeybee_radiance_command/options/pcomb.py
@@ -35,7 +35,7 @@ class PcombOptions(OptionCollection):
         OptionCollection.__init__(self)
 
         self._h = BoolOption("h", "Reduce information header - default: False")
-        self._w = BoolOption("w", "Supress warning messages - default: False")
+        self._w = BoolOption("w", "Suppress warning messages - default: False")
         self._x = IntegerOption("x", "X resolution", min_value=1)
         self._y = IntegerOption("y", "Y resolution", min_value=1)
         self._f = FileOption("f", "function file")

--- a/honeybee_radiance_command/options/pcompos.py
+++ b/honeybee_radiance_command/options/pcompos.py
@@ -1,0 +1,179 @@
+# coding: utf-8
+
+from .optionbase import (
+    OptionCollection,
+    BoolOption,
+    StringOption,
+    IntegerOption,
+    TupleOption
+)
+
+
+class PcomposOptions(OptionCollection):
+    """pcompos command options.
+
+    Also see: https://floyd.lbl.gov/radiance/man_html/pcompos.1.html
+    """
+
+    __slots__ = (
+        "_a",
+        "_s",
+        "_o",
+        "_h",
+        "_x",
+        "_y",
+        "_b",
+        "_l",
+        "_lh",
+        "_la"
+        )
+
+    def __init__(self):
+        """pcompos command options."""
+
+        OptionCollection.__init__(self)
+
+        self._a = IntegerOption("a", "Number of columns", min_value=1)
+        self._s = IntegerOption("s", "Spacing between images")
+        self._o = TupleOption(
+            "o", "Non-zero anchor point for bottom left as (x0, y0)",
+            length=2, value=None, numtype=int
+        )
+        self._h = BoolOption("h", "Reduce information header - default: False")
+        self._x = IntegerOption("x", "X resolution - default: 0")
+        self._y = IntegerOption("y", "Y resolution - default: 0")
+        self._b = TupleOption("b", "Background RGB", length=3, value=None, numtype=float)
+        self._l = StringOption("l", "Label for image")
+        self._lh = IntegerOption("lh", "Label height - default: 24 pixels")
+        self._la = BoolOption("la", "Label with file name - default: False")
+        self._on_setattr_check = False
+
+    @property
+    def a(self):
+        """Number of columns for which anchor points will be automatically computed.
+
+        It is assumed that anchor points place successive pictures next to each other
+        in ncols columns. The ordering will place the first picture in the lower
+        left corner, the next just to the right of it, and so on for ncols pictures.
+        Then, the next row up repeats the pattern until all the input pictures
+        have been added to the output. If the pictures are of different size,
+        pcompos will end up leaving some background areas in the output picture.
+        There will also be an unfinished row at the top if the number of pictures
+        is not evenly divided by ncols.
+        """
+        return self._a
+
+    @a.setter
+    def a(self, value):
+        self._a.value = value
+
+    @property
+    def s(self):
+        """Integer for pixel spacing between images.
+
+        The −s option causes each image to be separated by at least N pixels.
+        """
+        return self._s
+
+    @s.setter
+    def s(self, value):
+        self._s.value = value
+
+    @property
+    def o(self):
+        """Specify a nonzero anchor point for the bottom left image as (x0, y0).
+
+        This should be specified as a tuple of 2 integer values, denoting the X
+        and Y pixels of the origin.
+        """
+        return self._o
+
+    @o.setter
+    def o(self, value):
+        self._o.value = value
+
+    @property
+    def h(self):
+        """Reduce information header - default: False
+
+        The −h option may be used to reduce the information header size, which can
+        grow disproportionately after multiple runs of pcompos and/or pcomb.
+        """
+        return self._h
+
+    @h.setter
+    def h(self, value):
+        self._h.value = value
+
+    @property
+    def x(self):
+        """X dimension around the output image - default: 0
+
+        By default, the size of the output picture will be just large enough to
+        encompass all the input files. By specifying a smaller dimension using
+        the −x and −y options, input files can be cropped at the upper boundary.
+        Specifying a larger dimension produces a border.
+        """
+        return self._x
+
+    @x.setter
+    def x(self, value):
+        self._x.value = value
+
+    @property
+    def y(self):
+        """Y dimension around the output image - default: 0
+
+        By default, the size of the output picture will be just large enough to
+        encompass all the input files. By specifying a smaller dimension using
+        the −x and −y options, input files can be cropped at the upper boundary.
+        Specifying a larger dimension produces a border.
+        """
+        return self._y
+
+    @y.setter
+    def y(self, value):
+        self._y.value = value
+
+    @property
+    def b(self):
+        """RGB value for background color - default: (0, 0, 0)
+
+        The background color appears wherever input files do not cover.
+        """
+        return self._b
+
+    @b.setter
+    def b(self, value):
+        self._b.value = value
+
+    @property
+    def l(self):
+        """Text for a label for the output picture."""
+        return self._l
+
+    @l.setter
+    def l(self, value):
+        self._l.value = value
+
+    @property
+    def lh(self):
+        """Label height in pixels - default: 24"""
+        return self._lh
+
+    @lh.setter
+    def lh(self, value):
+        self._lh.value = value
+
+    @property
+    def la(self):
+        """Label images automatically according by name.
+
+        This is particularly useful in conjunction with the −a option for producing
+        a catalog of images.
+        """
+        return self._la
+
+    @la.setter
+    def la(self, value):
+        self._la.value = value

--- a/honeybee_radiance_command/options/pcond.py
+++ b/honeybee_radiance_command/options/pcond.py
@@ -75,7 +75,7 @@ class PcondOptions(OptionCollection):
         """Human visual response - default: False
 
         Mimic human visual response in the output. The goal of this process is to
-        produce output that correlates strongly with a person’s subjective
+        produce output that correlates strongly with a person's subjective
         impression of a scene. This switch is a bundle of the −a, −v, −s and −c options.
         """
         return self._h

--- a/honeybee_radiance_command/options/pfilt.py
+++ b/honeybee_radiance_command/options/pfilt.py
@@ -1,0 +1,328 @@
+# coding: utf-8
+
+from .optionbase import (
+    OptionCollection,
+    BoolOption,
+    StringOption,
+    IntegerOption,
+    NumericOption,
+    FileOption
+)
+
+
+class PfiltOptions(OptionCollection):
+    """pfilt command options.
+
+    Also see: https://floyd.lbl.gov/radiance/man_html/pfilt.1.html
+    """
+
+    __slots__ = (
+        "_x",
+        "_y",
+        "_p",
+        "_c",
+        "_e",
+        "_er",
+        "_eg",
+        "_eb",
+        "_t",
+        "_f",
+        "_1_",
+        "_2_",
+        "_b",
+        "_r",
+        "_m",
+        "_h",
+        "_n",
+        "_s",
+        "_a"
+        )
+
+    def __init__(self):
+        """pfilt command options."""
+
+        OptionCollection.__init__(self)
+
+        self._x = IntegerOption("x", "X resolution - default: same as input")
+        self._y = IntegerOption("y", "Y resolution - default: same as input")
+        self._p = NumericOption("p", "Pixel aspect ratio - default: 0")
+        self._c = BoolOption("c", "Do not write PIXASPECT variable - default: False")
+        self._e = NumericOption("e", "Exposure adjustment multiplier - default: 1")
+        self._er = NumericOption("er", "Red exposure adjustment multiplier")
+        self._eg = NumericOption("eg", "Green exposure adjustment multiplier")
+        self._eb = NumericOption("eb", "Blue exposure adjustment multiplier")
+        self._t = StringOption("t", "Fixture type to color balance")
+        self._f = FileOption("f", "Lamp lookup table file - default lib/lamp.tab")
+        self._1_ = BoolOption("_1", "Use only one pass on the file - default: False")
+        self._2_ = BoolOption("_2", "Use two passes on the file - default: True")
+        self._b = BoolOption("b", "Use box filtering - default: True")
+        self._r = NumericOption("r", "Use Gaussian filtering with specified radius")
+        self._m = NumericOption("m", "Limit given input pixels by a fraction")
+        self._h = NumericOption("h", "Pixel intensity considered 'hot' - default: 100")
+        self._n = IntegerOption("n", "Number of points on star patterns - default 0")
+        self._s = NumericOption("s", "Spread for star patterns - default: .0001")
+        self._a = BoolOption("a", "Average hot spots - default: False")
+
+    def _on_setattr(self):
+        """This method executes after setting each new attribute.
+
+        Use this method to add checks that are necessary for OptionCollection. For
+        instance in pcond option collection -f and -p don't go together very well.
+        You can include a check to ensure this is always correct.
+        """
+
+        if self._e.is_set and (self._er.is_set or self._eg.is_set or self._eb.is_set):
+            raise ValueError(
+                'Both -e and -er/-eg/-eb do not go well together.'
+                ' This program can use either of the options but not both.'
+            )
+
+    @property
+    def x(self):
+        """X resolution - default: same as input
+
+        Set the output x resolution to a number. This must be less than or equal
+        to the x dimension of the target device. If res is given as a slash
+        followed by a real number, the input resolution is divided by this
+        number to get the output resolution. By default, the output resolution
+        is the same as the input.
+        """
+        return self._x
+
+    @x.setter
+    def x(self, value):
+        self._x.value = value
+
+    @property
+    def y(self):
+        """Y resolution - default: same as input
+
+        Set the output y resolution to a number. This must be less than or equal
+        to the y dimension of the target device. If res is given as a slash
+        followed by a real number, the input resolution is divided by this
+        number to get the output resolution. By default, the output resolution
+        is the same as the input.
+        """
+        return self._y
+
+    @y.setter
+    def y(self, value):
+        self._y.value = value
+
+    @property
+    def p(self):
+        """Pixel aspect ratio - default: 0
+
+        Either the x or the y resolution will be reduced so that the pixels have
+        this ratio for the specified picture. If rat is zero, then the x and y
+        resolutions will adhere to the given maxima. Zero is the default.
+        """
+        return self._p
+
+    @p.setter
+    def p(self, value):
+        self._p.value = value
+
+    @property
+    def c(self):
+        """Do not write PIXASPECT variable - default: False
+
+        Pixel aspect ratio is being corrected, so do not write PIXASPECT variable
+        to output file.
+        """
+        return self._c
+
+    @c.setter
+    def c(self, value):
+        self._c.value = value
+
+    @property
+    def e(self):
+        """Exposure adjustment multiplier - default: 1
+
+        Adjust the exposure. If exp is preceded by a '+' or '-', the exposure is
+        interpreted in f-stops (ie. the power of two). Otherwise, exp is
+        interpreted as a straight multiplier.
+        """
+        return self._e
+
+    @e.setter
+    def e(self, value):
+        self._e.value = value
+
+    @property
+    def er(self):
+        """Exposure adjustment multiplier for Red channel."""
+        return self._er
+
+    @er.setter
+    def er(self, value):
+        self._er.value = value
+
+    @property
+    def eg(self):
+        """Exposure adjustment multiplier for Green channel."""
+        return self._eg
+
+    @eg.setter
+    def eg(self, value):
+        self._eg.value = value
+
+    @property
+    def eb(self):
+        """Exposure adjustment multiplier for Blue channel."""
+        return self._eb
+
+    @eb.setter
+    def eb(self, value):
+        self._eb.value = value
+
+    @property
+    def t(self):
+        """Fixture type to color balance.
+
+        Color-balance the image as if it were illuminated by fixtures of the
+        given type. The specification must match a pattern listed in the lamp
+        lookup table (see the −f option below).
+        """
+        return self._t
+
+    @t.setter
+    def t(self, value):
+        self._t.value = value
+
+    @property
+    def f(self):
+        """Lamp lookup table file - default lib.lamp.tab
+
+        Use the specified lamp lookup table rather than the default (lamp.tab).
+        """
+        return self._f
+
+    @f.setter
+    def f(self, value):
+        self._f.value = value
+
+    @property
+    def _1(self):
+        """Use only one pass on the file - default: False
+
+        This allows the exposure to be controlled absolutely, without any
+        averaging. Note that a single pass is much quicker and should be
+        used whenever the desired exposure is known and star patterns
+        are not required.
+        """
+        return self._1_
+
+    @_1.setter
+    def _1(self, value):
+        self._1_.value = value
+
+    @property
+    def _2(self):
+        """Use two passes on the input - default: True"""
+        return self._2_
+
+    @_2.setter
+    def _2(self, value):
+        self._2_.value = value
+
+    @property
+    def b(self):
+        """Use box filtering - default: True
+
+        Box filtering averages the input pixels corresponding to each separate
+        output pixel.
+        """
+        return self._b
+
+    @b.setter
+    def b(self, value):
+        self._b.value = value
+
+    @property
+    def r(self):
+        """Use Gaussian filtering with specified radius
+
+        Use Gaussian filtering with a specified radius relative to the output
+        pixel size. This option with a radius around 0.6 and a reduction in
+        image width and height of 2 or 3 produces the highest quality
+        pictures. A radius greater than 0.7 results in a defocused picture.
+        """
+        return self._r
+
+    @r.setter
+    def r(self, value):
+        self._r.value = value
+
+    @property
+    def m(self):
+        """Limit given input pixels by a fraction
+
+        Limit the influence of any given input pixel to a fraction of any given output
+        pixel. This option may be used to mitigate the problems associated with
+        inadequate image sampling, at the expense of a slightly blurred image.
+        The fraction given should not be less than the output picture dimensions
+        over the input picture dimensions (x_o*y_o/x_i/y_i), or blurring will
+        occur over the entire image. This option implies the −r option for Gaussian
+        filtering, which defaults to a radius of 0.6.
+        """
+        return self._m
+
+    @m.setter
+    def m(self, value):
+        self._m.value = value
+
+    @property
+    def h(self):
+        """Pixel intensity considered "hot" - default: 100 watts/sr/m2
+
+        Set intensity considered "hot" to a value. This is the level above which
+        areas of the image will begin to exhibit star diffraction patterns (see below).
+        The default is 100 watts/sr/m2.
+        """
+        return self._h
+
+    @h.setter
+    def h(self, value):
+        self._h.value = value
+
+    @property
+    def n(self):
+        """Number of points on star patterns - default 0
+
+        Set the number of points on star patterns to N. A value of zero turns
+        star patterns off. The default is 0. (Note that two passes are required
+        for star patterns.)
+        """
+        return self._n
+
+    @n.setter
+    def n(self, value):
+        self._n.value = value
+
+    @property
+    def s(self):
+        """Spread for star patterns - default: .0001
+
+        Set the spread for star patterns to val. This is the value a star pattern will
+        have at the edge of the image. The default is .0001.
+        """
+        return self._s
+
+    @s.setter
+    def s(self, value):
+        self._s.value = value
+
+    @property
+    def a(self):
+        """Average hot spots - default: False
+
+        By default, the areas of the picture above the hot level are not used in
+        setting the exposure.
+        """
+        return self._a
+
+    @a.setter
+    def a(self, value):
+        self._a.value = value

--- a/honeybee_radiance_command/options/psign.py
+++ b/honeybee_radiance_command/options/psign.py
@@ -1,0 +1,202 @@
+# coding: utf-8
+
+from .optionbase import (
+    OptionCollection,
+    BoolOption,
+    IntegerOption,
+    NumericOption,
+    FileOption,
+    TupleOption
+)
+
+
+class PsignOptions(OptionCollection):
+    """psign command options.
+
+    Also see: https://floyd.lbl.gov/radiance/man_html/psign.1.html
+    """
+
+    __slots__ = (
+        "_cb",
+        "_cf",
+        "_dr",
+        "_du",
+        "_dl",
+        "_dd",
+        "_h",
+        "_a",
+        "_x",
+        "_y",
+        "_s",
+        "_f"
+        )
+
+    def __init__(self):
+        """psign command options."""
+
+        OptionCollection.__init__(self)
+
+        self._cb = TupleOption(
+            "cb", "Background RGB - default: (1, 1, 1)", length=3, value=None,
+            numtype=float)
+        self._cf = TupleOption(
+            "cf", "Foreground RGB - default: (0, 0, 0)", length=3, value=None,
+            numtype=float)
+        self._dr = BoolOption("dr", "Text reads to the right - default: True")
+        self._du = BoolOption("du", "Text reads upwards - default: False")
+        self._dl = BoolOption("dl", "Text reads left (upside down) - default: False")
+        self._dd = BoolOption("dd", "Text reads downwards - default: False")
+        self._h = IntegerOption("h", "Character height - default: 32 pixels")
+        self._a = NumericOption("a", "Character aspect ratio (h/w) - default: 1.67")
+        self._x = IntegerOption("x", "Horizontal image size in pixels")
+        self._y = IntegerOption("y", "Vertical image size in pixels")
+        self._s = NumericOption("s", "Character spacing - default: 0")
+        self._f = FileOption("f", "Font file - default lib/helvet.fnt")
+
+    def _on_setattr(self):
+        """This method executes after setting each new attribute.
+
+        Use this method to add checks that are necessary for OptionCollection. For
+        instance in pcond option collection -f and -p don't go together very well.
+        You can include a check to ensure this is always correct.
+        """
+        all_orient = [1 for i in (self._dr, self._du, self._dl, self._dd) if i.is_set]
+        if sum(all_orient) > 1:
+            raise ValueError(
+                'Only one of the -dr, -du, -dl, -dd options can be set at a time.'
+            )
+
+    @property
+    def cb(self):
+        """Background RGB color - default: (1, 1, 1) for white"""
+        return self._cb
+
+    @cb.setter
+    def cb(self, value):
+        self._cb.value = value
+
+    @property
+    def cf(self):
+        """Foreground RGB color - default: (0, 0, 0) for black"""
+        return self._cf
+
+    @cf.setter
+    def cf(self, value):
+        self._cf.value = value
+
+    @property
+    def dr(self):
+        """Text reads to the right - default: True"""
+        return self._dr
+
+    @dr.setter
+    def dr(self, value):
+        self._dr.value = value
+
+    @property
+    def du(self):
+        """Text reads upwards - default: False"""
+        return self._du
+
+    @du.setter
+    def du(self, value):
+        self._du.value = value
+
+    @property
+    def dl(self):
+        """Text reads to the left - default: False"""
+        return self._dl
+
+    @dl.setter
+    def dl(self, value):
+        self._dl.value = value
+
+    @property
+    def dd(self):
+        """Text reads downwards - default: False"""
+        return self._dd
+
+    @dd.setter
+    def dd(self, value):
+        self._dd.value = value
+
+    @property
+    def h(self):
+        """Character height - default: 32 pixels"""
+        return self._h
+
+    @h.setter
+    def h(self, value):
+        self._h.value = value
+
+    @property
+    def a(self):
+        """Character aspect ratio (height/width) - default: 1.67"""
+        return self._a
+
+    @a.setter
+    def a(self, value):
+        self._a.value = value
+
+    @property
+    def x(self):
+        """Horizontal image size in pixels
+
+        Use with −y option in place of the −h specification to control output
+        image size directly. If the character aspect ratio (−a option, above)
+        is non-zero, then one of the specified x or y output dimensions may be
+        reduced to maintain this ratio. If direction is right (−dr) or left (−dl),
+        then it is not necessary to give the −y option, since it can be computed
+        from the character height (−h).
+        """
+        return self._x
+
+    @x.setter
+    def x(self, value):
+        self._x.value = value
+
+    @property
+    def y(self):
+        """Vertical image size in pixels
+
+        Use with the −x option. If direction is up (−du) or down (−dd), then it
+        is not necessary to give the −x option, since it can be computed from
+        the character height (−h).
+        """
+        return self._y
+
+    @y.setter
+    def y(self, value):
+        self._y.value = value
+
+    @property
+    def s(self):
+        """Character spacing - default: 0
+
+        The magnitude of this value is multiplied by the character height over the
+        aspect ratio (ie. the character width) to compute the desired distance between
+        characters in the output. The sign of the value, positive or negative,
+        determines how this ideal spacing is used in the actual placement of
+        characters. If spacing is positive, then the overall width of the line
+        will not be affected, nor will indentation of textual elements. Thus, the
+        text format will be mostly unaffected. However, spacing between characters
+        will reflect their relative size for a more natural appearance. If spacing
+        is negative, characters will be squeezed together to meet the spacing
+        criterion, regardless of how it might affect the format of the output. The
+        default value for spacing is zero, which is interpreted as uniformly
+        spaced characters.
+        """
+        return self._s
+
+    @s.setter
+    def s(self, value):
+        self._s.value = value
+
+    @property
+    def f(self):
+        """Font file - default lib/helvet.fnt"""
+        return self._f
+
+    @f.setter
+    def f(self, value):
+        self._f.value = value

--- a/honeybee_radiance_command/pcomb.py
+++ b/honeybee_radiance_command/pcomb.py
@@ -9,19 +9,28 @@ import honeybee_radiance_command._typing as typing
 
 
 class Pcomb(Command):
-    """pcomb command."""
+    """Pcomb command.
+
+    Pcomb combines equal-sized RADIANCE pictures and sends the result to the
+    standard output. By default, the result is just a linear combination of the
+    input pictures.
+
+    Args:
+        options: Command options. It will be set to Radiance default values if not
+            provided by user.
+        output: File path to the output file (Default: None).
+        input: A list of paths to radiance generated hdr images. (Default: None).
+
+    Properties:
+        * options
+        * output
+        * input
+    """
 
     __slots__ = ('_input')
 
-    def __init__(self, options=None, output=None, input=[]):
-        """Command.
-
-        Args:
-            options: Command options. It will be set to Radiance default values if not
-                provided by user.
-            output: File path to the output file (Default: None).
-            input: A list of paths to radiance generated hdr images. (Default: []).
-        """
+    def __init__(self, options=None, output=None, input=None):
+        """Initialize Command."""
         Command.__init__(self, output=output)
         self._input = input
         self.options = options
@@ -53,7 +62,7 @@ class Pcomb(Command):
         elif not isinstance(value, (list, tuple)):
             value = [value]
         for image in value:
-            if image[-4:].lower() != '.hdr':
+            if image[-4:].lower() not in ('.hdr', '.pic'):
                 raise ValueError(
                     'A list of .hdr files required. Instead got %s.' % (value)
                 )

--- a/honeybee_radiance_command/pcond.py
+++ b/honeybee_radiance_command/pcond.py
@@ -7,19 +7,31 @@ import honeybee_radiance_command._typing as typing
 
 
 class Pcond(Command):
-    """pcond command."""
+    """Pcond command.
+    
+    Pcond conditions a Radiance picture for output to a display or hard copy device.
+    If the dynamic range of the scene exceeds that of the display (as is usually the
+    case), pcond will compress the dynamic range of the picture such that both dark
+    and bright regions are visible. In addition, certain limitations in human
+    vision may be mimicked in order to provide an appearance similar to the
+    experience one might have in the actual scene.
+
+    Args:
+        options: Command options. It will be set to Radiance default values
+            if unspecified.
+        output: File path to the output file (Default: None).
+        input: File path to the radiance generated hdr file (Default: None).
+
+    Properties:
+        * options
+        * output
+        * input
+    """
 
     __slots__ = ('_input',)
 
     def __init__(self, options=None, output=None, input=None):
-        """Command.
-
-        Args:
-            options: Command options. It will be set to Radiance default values if not
-                provided by user.
-            output: File path to the output file (Default: None).
-            input: File path to the radiance generated hdr file (Default: None).
-        """
+        """Initialize Command."""
         Command.__init__(self, output=output)
         self.options = options
         self._input = input
@@ -46,7 +58,7 @@ class Pcond(Command):
 
     @input.setter
     def input(self, value):
-        if value[-4:].lower() != '.hdr':
+        if value[-4:].lower() not in ('.hdr', '.pic'):
             raise ValueError('"{}" does not have the expected extension for a Radiance '
                              'generated HDR.'.format(type(value)))
         else:

--- a/honeybee_radiance_command/pfilt.py
+++ b/honeybee_radiance_command/pfilt.py
@@ -1,16 +1,17 @@
-"""falsecolor command."""
+"""pfilt command."""
 
-from .options.falsecolor import FalsecolorOptions
+from .options.pfilt import PfiltOptions
 from ._command import Command
 import honeybee_radiance_command._exception as exceptions
 import honeybee_radiance_command._typing as typing
 
 
-class Falsecolor(Command):
-    """Falsecolor command.
+class Pfilt(Command):
+    """Pfilt command.
 
-    Falsecolor produces a false color picture for lighting analysis. Input is a
-    rendered Radiance picture.
+    Pfilt performs anti-aliasing and scaling on a RADIANCE picture. The program
+    makes two passes on the picture file in order to set the exposure to the correct
+    average value.
 
     Args:
         options: Command options. It will be set to Radiance default values
@@ -34,16 +35,16 @@ class Falsecolor(Command):
 
     @property
     def options(self):
-        """falsecolor options."""
+        """pfilt options."""
         return self._options
 
     @options.setter
     def options(self, value):
         if not value:
-            value = FalsecolorOptions()
+            value = PfiltOptions()
 
-        if not isinstance(value, FalsecolorOptions):
-            raise ValueError('Expected Falsecolor options not {}'.format(value))
+        if not isinstance(value, PfiltOptions):
+            raise ValueError('Expected Pfilt options not {}'.format(value))
 
         self._options = value
 
@@ -74,7 +75,7 @@ class Falsecolor(Command):
         cmd = ' '.join(command_parts)
 
         if not stdin_input and self.input:
-            cmd = '%s -i %s' % (cmd, self.input)
+            cmd = '%s %s' % (cmd, self.input)
 
         if self.pipe_to:
             cmd = '%s | %s' % (cmd, self.pipe_to.to_radiance(stdin_input=True))

--- a/honeybee_radiance_command/pflip.py
+++ b/honeybee_radiance_command/pflip.py
@@ -7,19 +7,26 @@ import honeybee_radiance_command._typing as typing
 
 
 class Pflip(Command):
-    """pflip command."""
+    """Pflip command.
+
+    Pflip flips a RADIANCE picture horizontally and/or vertically.
+
+    Args:
+        options: Command options. It will be set to Radiance default values
+            if unspecified.
+        output: File path to the output file (Default: None).
+        input: File path to the radiance generated hdr file (Default: None).
+
+    Properties:
+        * options
+        * output
+        * input
+    """
 
     __slots__ = ('_input',)
 
     def __init__(self, options=None, output=None, input=None):
-        """Command.
-
-        Args:
-            options: Command options. It will be set to Radiance default values if not
-                provided by user.
-            output: File path to the output file (Default: None).
-            input: File path to the radiance generated hdr file (Default: None).
-        """
+        """Initialize Command."""
         Command.__init__(self, output=output)
         self.options = options
         self._input = input
@@ -46,7 +53,7 @@ class Pflip(Command):
 
     @input.setter
     def input(self, value):
-        if value[-4:].lower() != '.hdr':
+        if value[-4:].lower() not in ('.hdr', '.pic'):
             raise ValueError('"{}" does not have the expected extension for a Radiance '
                              'generated HDR.'.format(type(value)))
         else:

--- a/honeybee_radiance_command/psign.py
+++ b/honeybee_radiance_command/psign.py
@@ -1,64 +1,61 @@
-"""falsecolor command."""
+"""psign command."""
 
-from .options.falsecolor import FalsecolorOptions
+from .options.psign import PsignOptions
 from ._command import Command
 import honeybee_radiance_command._exception as exceptions
 import honeybee_radiance_command._typing as typing
 
 
-class Falsecolor(Command):
-    """Falsecolor command.
+class Psign(Command):
+    """Psign command.
 
-    Falsecolor produces a false color picture for lighting analysis. Input is a
-    rendered Radiance picture.
+    Psign produces a RADIANCE picture of the given text. The output dimensions
+    are determined by the character height, aspect ratio, number of lines and
+    line length. (Also the character size if text squeezing is used.)
 
     Args:
         options: Command options. It will be set to Radiance default values
             if unspecified.
         output: File path to the output file (Default: None).
-        input: File path to the radiance generated hdr file (Default: None).
+        text: Text which will be converted into an image (Default: None).
 
     Properties:
         * options
         * output
-        * input
+        * text
     """
 
-    __slots__ = ('_input',)
+    __slots__ = ('_text',)
 
-    def __init__(self, options=None, output=None, input=None):
+    def __init__(self, options=None, output=None, text=None):
         """Initialize Command."""
         Command.__init__(self, output=output)
         self.options = options
-        self._input = input
+        self._text = text
 
     @property
     def options(self):
-        """falsecolor options."""
+        """psign options."""
         return self._options
 
     @options.setter
     def options(self, value):
         if not value:
-            value = FalsecolorOptions()
+            value = PsignOptions()
 
-        if not isinstance(value, FalsecolorOptions):
-            raise ValueError('Expected Falsecolor options not {}'.format(value))
+        if not isinstance(value, PsignOptions):
+            raise ValueError('Expected Psign options not {}'.format(value))
 
         self._options = value
 
     @property
-    def input(self):
-        """Radiance HDR image file."""
-        return self._input
+    def text(self):
+        """Text string to be converted into an image."""
+        return self._text
 
-    @input.setter
-    def input(self, value):
-        if value[-4:].lower() not in ('.hdr', '.pic'):
-            raise ValueError('"{}" does not have the expected extension for a Radiance '
-                             'generated HDR.'.format(type(value)))
-        else:
-            self._input = typing.normpath(value)
+    @text.setter
+    def text(self, value):
+        self._text = str(value)
 
     def to_radiance(self, stdin_input=False):
         """Command in Radiance format.
@@ -73,8 +70,8 @@ class Falsecolor(Command):
         command_parts = [self.command, self.options.to_radiance()]
         cmd = ' '.join(command_parts)
 
-        if not stdin_input and self.input:
-            cmd = '%s -i %s' % (cmd, self.input)
+        if not stdin_input and self.text:
+            cmd = '%s "%s"' % (cmd, self.text)
 
         if self.pipe_to:
             cmd = '%s | %s' % (cmd, self.pipe_to.to_radiance(stdin_input=True))
@@ -86,5 +83,5 @@ class Falsecolor(Command):
 
     def validate(self, stdin_input=False):
         Command.validate(self)
-        if not stdin_input and not self.input:
-            raise exceptions.MissingArgumentError(self.command, 'input')
+        if not stdin_input and not self.text:
+            raise exceptions.MissingArgumentError(self.command, 'text')

--- a/honeybee_radiance_command/ra_gif.py
+++ b/honeybee_radiance_command/ra_gif.py
@@ -9,7 +9,24 @@ import honeybee_radiance_command._exception as exceptions
 
 
 class Ra_GIF(Command):
-    """ra_gif command."""
+    """Ra_gif command.
+
+    Ra_gif converts from RADIANCE to Compuserve GIF color-mapped, compressed
+    image files. In the default mode, a RADIANCE picture is converted to a
+    color-mapped GIF file of the same horizontal and vertical dimensions with
+    8-bits per pixel.
+
+    Args:
+        options: Command options. It will be set to Radiance default values
+            if unspecified.
+        output: File path to the output file (Default: None).
+        input: File path to the radiance generated hdr file (Default: None).
+
+    Properties:
+        * options
+        * output
+        * input
+    """
 
     __slots__ = ('_input')
 
@@ -40,7 +57,7 @@ class Ra_GIF(Command):
 
     @input.setter
     def input(self, value):
-        if value[-4:].lower() != '.hdr':
+        if value[-4:].lower() not in ('.hdr', '.pic'):
             raise ValueError('"{}" does not have the expected extension for a Radiance '
                              'generated HDR.'.format(type(value)))
         else:

--- a/honeybee_radiance_command/rcalc.py
+++ b/honeybee_radiance_command/rcalc.py
@@ -17,19 +17,22 @@ class Rcalc(Command):
     numeric fields separated by tabs. The -tS option is used to specify an alternate tab
     character.
 
-    See RcalcOptions for more information.
+    Args:
+        options: Rcalc command options. It will be set to Radiance default values
+            if unspecified.
+        output: Output file (Default: None).
+        inputs: A collection of scene files (Default: None)
+
+    Properties:
+        * options
+        * output
+        * input
     """
 
     __slots__ = ('_inputs',)
 
     def __init__(self, options=None, output=None, inputs=None):
-        """Rcalc command.
-
-        Args:
-            options: Rcalc command (Default: RcalcOptions()).
-            output: Output file (Default: None).
-            inputs: A collection of scene files (Default: [])
-        """
+        """Initialize Command."""
         Command.__init__(self, output=output)
         self.inputs = inputs or []
         self.options = options

--- a/honeybee_radiance_command/rcontrib.py
+++ b/honeybee_radiance_command/rcontrib.py
@@ -13,7 +13,18 @@ class Rcontrib(Rtrace):
     RAYPATH environment variable determines directories to search for this file. (No
     search takes place if a file name begins with a '.', '/' or '~' character.).
 
-    See RcontribOptions class for more information.
+    Args:
+        options: Command options. It will be set to Radiance default values
+            if unspecified.
+        output: Output file (Default: None).
+        octree: Octree file (Default: None).
+        sensors: Sensors file (Default: None).
+
+    Properties:
+        * options
+        * output
+        * octree
+        * sensors
 
     Note:
     https://www.radiance-online.org/learning/documentation/manual-pages/pdfs/rcontrib.pdf

--- a/honeybee_radiance_command/rpict.py
+++ b/honeybee_radiance_command/rpict.py
@@ -9,17 +9,21 @@ import honeybee_radiance_command._typing as typing
 class Rpict(Command):
     """Rpict Command.
 
+    Rpict generates a picture from the RADIANCE scene given in octree and sends
+    it to the standard output.
+
     Args:
-        options: Command options. It will be set to Radiance default values if not
-            provided by user.
+        options: Command options. It will be set to Radiance default values
+            if unspecified.
         output: File path to the output file (Default: None).
         octree: File path to the octree file (Default: None).
         view: File path to a view file (Default: None).
 
     Properties:
-        *options
-        *octree
-        *view
+        * options
+        * output
+        * octree
+        * view
     """
 
     __slots__ = ('_octree', '_view')

--- a/honeybee_radiance_command/rtrace.py
+++ b/honeybee_radiance_command/rtrace.py
@@ -6,19 +6,23 @@ import honeybee_radiance_command._typing as typing
 
 
 class Rtrace(Command):
-    """Rtrace ommand.
+    """Rtrace command.
+
+    Rtrace traces rays from the standard input through the RADIANCE scene given
+    by octree and sends the results to the standard output.
 
     Args:
-        options: Command options. It will be set to Radiance default values if not
-            provided by user.
+        options: Command options. It will be set to Radiance default values
+            if unspecified.
         output: Output file (Default: None).
         octree: Octree file (Default: None).
         sensors: Sensors file (Default: None).
 
     Properties:
-        *options
-        *octree
-        *sensors
+        * options
+        * output
+        * octree
+        * sensors
     """
 
     __slots__ = ('_octree', '_sensors')

--- a/tests/evalglare_test.py
+++ b/tests/evalglare_test.py
@@ -1,0 +1,50 @@
+from honeybee_radiance_command.evalglare import Evalglare
+import pytest
+import honeybee_radiance_command._exception as exceptions
+
+
+def test_defaults():
+    """Test command."""
+    evalglare = Evalglare()
+    assert evalglare.command == 'evalglare'
+    assert evalglare.options.to_radiance() == ''
+
+
+def test_assignment():
+    """Test assignment."""
+    evalglare = Evalglare()
+
+    evalglare.input = 'image.hdr'
+    assert evalglare.input == 'image.hdr'
+    assert evalglare.to_radiance() == 'evalglare image.hdr'
+    evalglare.output = 'conditioned_image.hdr'
+    assert evalglare.output == 'conditioned_image.hdr'
+    assert evalglare.to_radiance() == 'evalglare image.hdr > conditioned_image.hdr'
+
+
+def test_options():
+    """Test options."""
+    evalglare = Evalglare()
+
+    evalglare.input = 'image.hdr'
+    evalglare.options.c = 'checkfile.hdr'
+    evalglare.options.d = True
+    assert evalglare.to_radiance() == 'evalglare -c checkfile.hdr -d image.hdr'
+
+
+def test_stdin():
+    """Test stdin."""
+    evalglare = Evalglare()
+
+    evalglare.input = 'image.hdr'
+    evalglare.output = 'conditioned.hdr'
+    assert evalglare.to_radiance(stdin_input=True) == ('evalglare > conditioned.hdr')
+
+
+def test_validation():
+    """Test if exception is raised for missing arguments."""
+    evalglare = Evalglare()
+    with pytest.raises(exceptions.MissingArgumentError):
+        evalglare.to_radiance()
+    evalglare.input = 'image.hdr'
+    assert evalglare.to_radiance() == 'evalglare image.hdr'

--- a/tests/falsecolor_test.py
+++ b/tests/falsecolor_test.py
@@ -31,7 +31,6 @@ def test_options():
     falsecolor.options.s = 'auto'
     falsecolor.options.l = 'lux'
     falsecolor.options.cl = True
-    print(falsecolor.options.s)
     assert falsecolor.to_radiance() == 'falsecolor -cl -l lux -pal spec -s auto -i image.hdr'
 
 

--- a/tests/getinfo_test.py
+++ b/tests/getinfo_test.py
@@ -1,0 +1,52 @@
+from honeybee_radiance_command.getinfo import Getinfo
+import pytest
+import honeybee_radiance_command._exception as exceptions
+
+
+def test_defaults():
+    """Test command."""
+    getinfo = Getinfo()
+
+    assert getinfo.command == 'getinfo'
+    assert getinfo.options.to_radiance() == ''
+
+
+def test_assignment():
+    """Test assignment."""
+    getinfo = Getinfo()
+
+    getinfo.input = ['image1.hdr', 'image2.hdr']
+    assert getinfo.input == 'image1.hdr image2.hdr'
+    assert getinfo.to_radiance() == 'getinfo image1.hdr image2.hdr'
+    getinfo.output = 'combined.hdr'
+    assert getinfo.output == 'combined.hdr'
+    assert getinfo.to_radiance() == 'getinfo image1.hdr image2.hdr > combined.hdr'
+
+
+def test_assignment_options():
+    """Test assigning options."""
+    getinfo = Getinfo()
+
+    getinfo.input = ['image1.hdr', 'image2.hdr']
+    getinfo.options.d = True
+    assert getinfo.to_radiance() == 'getinfo -d image1.hdr image2.hdr'
+
+
+def test_stdin():
+    """Test stdin."""
+    getinfo = Getinfo()
+
+    getinfo.input = ['image1.hdr', 'image2.hdr']
+    getinfo.output = 'combined.hdr'
+    assert getinfo.to_radiance(stdin_input=True) == ('getinfo > combined.hdr')
+
+
+def test_validation():
+    """Validate error for missing argument."""
+    getinfo = Getinfo()
+
+    with pytest.raises(exceptions.MissingArgumentError):
+        getinfo.to_radiance()
+
+    getinfo.input = ['image1.hdr', 'image2.hdr']
+    assert getinfo.to_radiance() == 'getinfo image1.hdr image2.hdr'

--- a/tests/pcomb_test.py
+++ b/tests/pcomb_test.py
@@ -24,7 +24,7 @@ def test_assignment():
 
 
 def test_assignment_options():
-    """Test assignning options."""
+    """Test assigning options."""
     pcomb = Pcomb()
 
     pcomb.input = ['image1.hdr', 'image2.hdr']

--- a/tests/pcompos_test.py
+++ b/tests/pcompos_test.py
@@ -1,0 +1,53 @@
+from honeybee_radiance_command.pcompos import Pcompos
+import pytest
+import honeybee_radiance_command._exception as exceptions
+
+
+def test_defaults():
+    """Test command."""
+    pcompos = Pcompos()
+
+    assert pcompos.command == 'pcompos'
+    assert pcompos.options.to_radiance() == ''
+
+
+def test_assignment():
+    """Test assignment."""
+    pcompos = Pcompos()
+
+    pcompos.input = ['image1.hdr', 'image2.hdr']
+    assert pcompos.input == 'image1.hdr image2.hdr'
+    assert pcompos.to_radiance() == 'pcompos image1.hdr image2.hdr'
+    pcompos.output = 'combined.hdr'
+    assert pcompos.output == 'combined.hdr'
+    assert pcompos.to_radiance() == 'pcompos image1.hdr image2.hdr > combined.hdr'
+
+
+def test_assignment_options():
+    """Test assigning options."""
+    pcompos = Pcompos()
+
+    pcompos.input = ['image1.hdr', 'image2.hdr']
+    pcompos.options.h = True
+    pcompos.options.a = 1
+    assert pcompos.to_radiance() == 'pcompos -a 1 -h image1.hdr image2.hdr'
+
+
+def test_stdin():
+    """Test stdin."""
+    pcompos = Pcompos()
+
+    pcompos.input = ['image1.hdr', 'image2.hdr']
+    pcompos.output = 'combined.hdr'
+    assert pcompos.to_radiance(stdin_input=True) == ('pcompos > combined.hdr')
+
+
+def test_validation():
+    """Validate error for missing argument."""
+    pcompos = Pcompos()
+
+    with pytest.raises(exceptions.MissingArgumentError):
+        pcompos.to_radiance()
+
+    pcompos.input = ['image1.hdr', 'image2.hdr']
+    assert pcompos.to_radiance() == 'pcompos image1.hdr image2.hdr'

--- a/tests/pfilt_test.py
+++ b/tests/pfilt_test.py
@@ -1,0 +1,49 @@
+from honeybee_radiance_command.pfilt import Pfilt
+import pytest
+import honeybee_radiance_command._exception as exceptions
+
+
+def test_defaults():
+    """Test command."""
+    pfilt = Pfilt()
+    assert pfilt.command == 'pfilt'
+    assert pfilt.options.to_radiance() == ''
+
+
+def test_assignment():
+    """Test assignment."""
+    pfilt = Pfilt()
+
+    pfilt.input = 'image.hdr'
+    assert pfilt.input == 'image.hdr'
+    assert pfilt.to_radiance() == 'pfilt image.hdr'
+    pfilt.output = 'conditioned_image.hdr'
+    assert pfilt.output == 'conditioned_image.hdr'
+    assert pfilt.to_radiance() == 'pfilt image.hdr > conditioned_image.hdr'
+
+
+def test_options():
+    """Test options."""
+    pfilt = Pfilt()
+
+    pfilt.input = 'image.hdr'
+    pfilt.options._1 = True
+    assert pfilt.to_radiance() == 'pfilt -1 image.hdr'
+
+
+def test_stdin():
+    """Test stdin."""
+    pfilt = Pfilt()
+
+    pfilt.input = 'image.hdr'
+    pfilt.output = 'conditioned.hdr'
+    assert pfilt.to_radiance(stdin_input=True) == ('pfilt > conditioned.hdr')
+
+
+def test_validation():
+    """Test if exception is raised for missing arguments."""
+    pfilt = Pfilt()
+    with pytest.raises(exceptions.MissingArgumentError):
+        pfilt.to_radiance()
+    pfilt.input = 'image.hdr'
+    assert pfilt.to_radiance() == 'pfilt image.hdr'

--- a/tests/psign_test.py
+++ b/tests/psign_test.py
@@ -1,0 +1,50 @@
+from honeybee_radiance_command.psign import Psign
+import pytest
+import honeybee_radiance_command._exception as exceptions
+
+
+def test_defaults():
+    """Test command."""
+    psign = Psign()
+    assert psign.command == 'psign'
+    assert psign.options.to_radiance() == ''
+
+
+def test_assignment():
+    """Test assignment."""
+    psign = Psign()
+
+    psign.text = '21 Jun 12:00'
+    assert psign.text == '21 Jun 12:00'
+    assert psign.to_radiance() == 'psign "21 Jun 12:00"'
+    psign.output = 'conditioned_image.hdr'
+    assert psign.output == 'conditioned_image.hdr'
+    assert psign.to_radiance() == 'psign "21 Jun 12:00" > conditioned_image.hdr'
+
+
+def test_options():
+    """Test options."""
+    psign = Psign()
+
+    psign.text = '21 Jun 12:00'
+    psign.options.cb = (0, 0, 0)
+    psign.options.cf = (1, 1, 1)
+    assert psign.to_radiance() == 'psign -cb 0.0 0.0 0.0 -cf 1.0 1.0 1.0 "21 Jun 12:00"'
+
+
+def test_stdin():
+    """Test stdin."""
+    psign = Psign()
+
+    psign.text = '21 Jun 12:00'
+    psign.output = 'conditioned.hdr'
+    assert psign.to_radiance(stdin_input=True) == ('psign > conditioned.hdr')
+
+
+def test_validation():
+    """Test if exception is raised for missing arguments."""
+    psign = Psign()
+    with pytest.raises(exceptions.MissingArgumentError):
+        psign.to_radiance()
+    psign.text = '21 Jun 12:00'
+    assert psign.to_radiance() == 'psign "21 Jun 12:00"'


### PR DESCRIPTION
I just decided to add everything that I will need for all image processing, including `pcompos`, `pfilt`, `getinfo`, and `evalglare`. I even added the `psign` command because it was quick and I know of several occasions where people have asked for this type of image labeling functionality on the forum.

Lastly, I cleaned up the docstrings, which I realized were following the old format that is not compatible with our sphinx template.

CC: @mostaphaRoudsari 