### PR TITLE
fix(optionbase): Ensure that IronPython exception is caught

### DIFF
--- a/honeybee_radiance_command/options/optionbase.py
+++ b/honeybee_radiance_command/options/optionbase.py
@@ -484,10 +484,10 @@ class OptionCollection(object):
     def __setattr__(self, name, value):
         try:
             object.__setattr__(self, name, value)
-        except AttributeError:
+        except (AttributeError, SystemError):
             try:
                 object.__setattr__(self, name + '_', value)
-            except AttributeError:
+            except (AttributeError, SystemError):
                 raise AttributeError(
                     '"{1}" object has no attribute "{0}".'
                     '\nYou can still try to use `update_from_string` method to add or'


### PR DESCRIPTION
It seems that the IronPython interpreter does not raise an AttributeError where it is supposed to and we need to use SystemError.