### PR TITLE
fix(command): Ensure output paths with spaces are properly handled

### DIFF
--- a/honeybee_radiance_command/_command.py
+++ b/honeybee_radiance_command/_command.py
@@ -63,10 +63,10 @@ rtrace.run(env)
 """
 
 import warnings
-import os
 
 from .options import OptionCollection
 from ._command_util import run_command
+import honeybee_radiance_command._typing as typing
 
 
 class Command(object):
@@ -107,7 +107,7 @@ class Command(object):
     @output.setter
     def output(self, value):
         if value:
-            value = os.path.normpath(value)
+            value = typing.normpath(value)
         self._output = value
 
     @property

--- a/honeybee_radiance_command/gendaylit.py
+++ b/honeybee_radiance_command/gendaylit.py
@@ -53,9 +53,9 @@ class Gendaylit(Gensky):
 
     def __init__(self, month=None, day=None, time=None, time_zone=None,
                  solar_time=False, options=None, output=None):
-        
+
         Gensky.__init__(self, month=month, day=day, time=time, time_zone=time_zone,
-            solar_time=solar_time, options=options, output=output)
+                        solar_time=solar_time, options=options, output=output)
 
     @property
     def options(self):


### PR DESCRIPTION
Only doing normpath still resulted in some cases of failures. This should fix the issue.