### PR TITLE
fix(rcontrib):  Fixed a options bug relating to on_setattr mehod

### DIFF
--- a/honeybee_radiance_command/options/rcontrib.py
+++ b/honeybee_radiance_command/options/rcontrib.py
@@ -54,10 +54,11 @@ class RcontribOptions(RtraceOptions):
         instance in rtrace option collection -ti and -te are exclusive. You can include a
         check to ensure this is always correct.
         """
-        RtraceOptions._on_setattr(self)
-        # -r and -fo cannot both be True.
         if not hasattr(self, 'r'):
             return  # this happens on init
+        # -i and -I cannot both be True.
+        assert not (self.i == True and self.I == True), \
+            'You can either set -i or -I to True not both.'
         if self.r.is_set and self.fo.is_set:
             raise exceptions.ExclusiveOptionsError(self.command, 'r', 'fo')
         if self.m.is_set and self.M.is_set:


### PR DESCRIPTION
I removed the call to on_setattr from the super class (rtrace) as most of the options being invoked and checked there are not relevant to rcontrib or rfluxmtx.