### PR TITLE
fix(options): add support for % in radiance options

### DIFF
--- a/honeybee_radiance_command/options/optionbase.py
+++ b/honeybee_radiance_command/options/optionbase.py
@@ -471,7 +471,9 @@ class OptionCollection(object):
         additional_options = \
             ' '.join('-%s %s' % (k, v) for k, v in self.additional_options.items())
 
-        return ' '.join(' '.join((options, additional_options)).split())
+        # handle replace %% with % to handle % in both Window and Unix
+        return ' '.join(
+            ' '.join((options, additional_options)).split()).replace('%%', '%')
 
     def to_file(self, folder, file_name, mkdir=False):
         """Write options to a file."""

--- a/honeybee_radiance_command/options/rcontrib.py
+++ b/honeybee_radiance_command/options/rcontrib.py
@@ -276,4 +276,5 @@ class RcontribOptions(RtraceOptions):
             ' '.join(
                 '-%s %s' % (k, v) for k, v in self.additional_options.items())
 
-        return ' '.join(' '.join((options, additional_options)).split())
+        return ' '.join(
+            ' '.join((options, additional_options)).split()).replace('%%', '%')

--- a/tests/options/options_test.py
+++ b/tests/options/options_test.py
@@ -1,6 +1,6 @@
 """Test Radiance commands options base classes."""
 from honeybee_radiance_command.options import StringOptionJoined, NumericOption, \
-    IntegerOption, BoolOption,  OptionCollection
+    IntegerOption, BoolOption,  OptionCollection, StringOption
 import pytest
 import honeybee_radiance_command._exception as exceptions
 
@@ -64,7 +64,7 @@ def test_bool_option():
 
 class OptionsTestClass(OptionCollection):
 
-    __slots__ = ('_ab', '_aa', '_ld', '_fa', '_as')
+    __slots__ = ('_ab', '_aa', '_ld', '_fa', '_as', '_o')
 
     def __init__(self):
         OptionCollection.__init__(self)
@@ -73,6 +73,7 @@ class OptionsTestClass(OptionCollection):
         self._ld = BoolOption('ld', 'limit distance')
         self._fa = StringOptionJoined('fa', 'output format', valid_values=['a', 'd'])
         self._as = IntegerOption('as', 'ambient somthing!', min_value=0)
+        self._o = StringOption('o', 'output file format.')
 
     @property
     def ab(self):
@@ -114,6 +115,15 @@ class OptionsTestClass(OptionCollection):
     def as_(self, value):
         self._as.value = value
 
+    @property
+    def o(self):
+        """Format output."""
+        return self._o
+
+    @o.setter
+    def o(self, value):
+        self._o.value = value
+
 
 def test_collection():
     options_test = OptionsTestClass()
@@ -127,5 +137,7 @@ def test_collection():
     options_test.ld = True
     assert options_test.to_radiance() == '-as 128 -ld -ad 2500'
 
+    options_test.o = '%%s.vmtx'
+    assert '-o %s.vmtx' in options_test.to_radiance()
     with pytest.raises(AttributeError):
         options_test.ad = 2400


### PR DESCRIPTION
Several radiance parameters accept values with % as an input. The challenge is that Windows and Unix command line parser work differently with %. In Windows one needs to use %% to make % literal. In Unix it should be passed as %.

To address this issue we will pass %% by default and then find and replace them with % before writing them to Radiance.