### PR TITLE
fix(dcglare): Remove redundant warning

### DIFF
--- a/honeybee_radiance_command/options/dcglare.py
+++ b/honeybee_radiance_command/options/dcglare.py
@@ -56,10 +56,6 @@ class DcglareOptions(OptionCollection):
         if self._vf.is_set and self._vu.is_set:
             warnings.warn(
                 'Both -vf and -vu are set. %s will ignore -vu.' % self.command)
-        if self._sf.is_set and not self._l.is_set:
-            warnings.warn(
-                '-sf is set but -l is not. %s will ignore -sf if -ls is not set.'
-                % self.command)
         if self._ss.is_set and not self._l.is_set:
             warnings.warn(
                 '-ss is set but -l is not. %s will ignore -ss if -ls is not set.'

--- a/honeybee_radiance_command/rmtxop.py
+++ b/honeybee_radiance_command/rmtxop.py
@@ -242,6 +242,8 @@ class Rmtxop(Command):
                 comes from stdin. This is for instance the case when you pipe the input
                 from another command (default: False).
         """
+        if stdin_input:
+            self.matrices = '-'
         self.validate(stdin_input)
 
         command_parts = [self.command, self.options.to_radiance()]

--- a/tests/rmtxop_test.py
+++ b/tests/rmtxop_test.py
@@ -100,3 +100,12 @@ def test_input_matrix_limit():
     rmtxop.matrices = ['dc1.mtx', 'dc2.mtx', 'dc3.mtx', 'dc4.mtx', 'dc5.mtx']
     with pytest.raises(AssertionError):
         rmtxop.validate()
+
+
+def test_stdin_input():
+    """Test assignments."""
+    rmtxop = Rmtxop()
+
+    rmtxop.matrices = ['dc.mtx', 'sky.mtx']
+    rmtxop.transforms = [['47.4', '119.9', '11.6']]
+    assert rmtxop.to_radiance(stdin_input=True) == 'rmtxop -c 47.4 119.9 11.6 -'


### PR DESCRIPTION
I also added support for piping to rmtxop.