### PR TITLE
fix(rcalc): Prevent misleading warning about no inputs

### DIFF
--- a/honeybee_radiance_command/rcalc.py
+++ b/honeybee_radiance_command/rcalc.py
@@ -94,5 +94,3 @@ class Rcalc(Command):
 
     def validate(self):
         Command.validate(self)
-        if len(self.inputs) == 0:
-            warnings.warn('rcalc: no inputs.')

--- a/tests/rcalc_test.py
+++ b/tests/rcalc_test.py
@@ -11,9 +11,6 @@ def test_defaults():
     with warnings.catch_warnings(record=True) as w:
         warnings.simplefilter('always')
         rcalc.to_radiance()
-        # verify a warning has been raised for empty scene.
-        assert len(w) == 1
-        assert 'no inputs.' in str(w[0].message)
 
 
 input_path = 'result/input.dat'


### PR DESCRIPTION
This has been showing up unnecessarily in every recipe since we are piping things into the command. So I'm removing it here.